### PR TITLE
Outfit(addons) & Mounts database changes

### DIFF
--- a/data/migrations/34.lua
+++ b/data/migrations/34.lua
@@ -1,3 +1,61 @@
 function onUpdateDatabase()
-	return false
+	print("> Updating database to version 34 (re work on outfits(addons) & mount saving/loading)")
+	
+	db.query([[
+		CREATE TABLE IF NOT EXISTS `player_outfits` (`player_id` int DEFAULT 0 NOT NULL,`outfit_id` smallint unsigned DEFAULT 0 NOT NULL,`addons` tinyint unsigned DEFAULT 0 NOT NULL,
+		PRIMARY KEY (`player_id`,`outfit_id`), 
+		FOREIGN KEY (`player_id`) REFERENCES `players`(`id`) ON DELETE CASCADE)
+		ENGINE=InnoDB DEFAULT CHARACTER SET=utf8;
+	]])
+
+	db.query([[
+		CREATE TABLE IF NOT EXISTS `player_mounts` (`player_id` int DEFAULT 0 NOT NULL,`mount_id` smallint unsigned DEFAULT 0 NOT NULL,
+		PRIMARY KEY (`player_id`,`mount_id`),
+		FOREIGN KEY (`player_id`) REFERENCES `players`(`id`) ON DELETE CASCADE)
+		ENGINE=InnoDB DEFAULT CHARACTER SET=utf8;
+	]])
+
+	db.query([[
+		ALTER TABLE `players`
+    	ADD `currentmount` smallint unsigned NOT NULL DEFAULT 0 AFTER `lookmountfeet`;
+	]])
+
+	local outfitRange = 10001000
+	local mountRange = 10002001
+
+	local resultId = db.storeQuery(string.format("SELECT `player_id`, `value` FROM `player_storage` WHERE `key` >= %d AND `key` <= %d", outfitRange, outfitRange + 500))
+	if resultId then
+		repeat
+			local playerId = result.getNumber(resultId, "player_id")
+			local outfitId = bit.rshift(result.getNumber(resultId, "value"), 16)
+			local addons = bit.band(result.getNumber(resultId, "value"), 0xFF)
+			
+			db.query(string.format("INSERT INTO `player_outfits` (`player_id`, `outfit_id`, `addons`) VALUES (%d, %d, %d)", playerId, outfitId, addons))
+		until not result.next(resultId)
+		result.free(resultId)
+	end
+
+	local resultId = db.storeQuery(string.format("SELECT `player_id`, `key`, `value` FROM `player_storage` WHERE `key`>= %d AND `key` < %d", mountRange, mountRange + 10))
+	if resultId then
+		repeat
+			for i = 1, 200 do
+				local key = mountRange + ((i-1) / 31)
+				if key == result.getNumber(resultId, "key") then
+					local playerId = result.getNumber(resultId, "player_id")
+					local lshift = bit.lshift(1, ((i-1) % 31))
+					local mount = bit.band(lshift, result.getNumber(resultId, "value"))
+
+					if mount ~= 0 then
+						db.query(string.format("INSERT INTO `player_mounts` (`player_id`, `mount_id`) VALUES (%d, %d)", playerId, i))
+					end
+				end
+			end
+		until not result.next(resultId)
+		result.free(resultId)
+	end
+
+	-- deleting all outfit & mount storages at once
+	db.asyncQuery(string.format("DELETE FROM `player_storage` WHERE `key` >= %d AND `key` <= %d OR `key` >= %d AND `key` <= %d", outfitRange, outfitRange + 500, mountRange, mountRange + 10))
+
+	return true
 end

--- a/data/migrations/35.lua
+++ b/data/migrations/35.lua
@@ -1,0 +1,3 @@
+function onUpdateDatabase()
+	return false
+end

--- a/schema.sql
+++ b/schema.sql
@@ -32,6 +32,7 @@ CREATE TABLE IF NOT EXISTS `players` (
   `lookmountbody` int NOT NULL DEFAULT '0',
   `lookmountlegs` int NOT NULL DEFAULT '0',
   `lookmountfeet` int NOT NULL DEFAULT '0',
+  `currentmount` smallint unsigned NOT NULL DEFAULT '0',
   `randomizemount` tinyint NOT NULL DEFAULT '0',
   `direction` tinyint unsigned NOT NULL DEFAULT '2',
   `maglevel` int NOT NULL DEFAULT '0',
@@ -341,6 +342,21 @@ CREATE TABLE IF NOT EXISTS `player_storage` (
   FOREIGN KEY (`player_id`) REFERENCES `players`(`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARACTER SET=utf8;
 
+CREATE TABLE IF NOT EXISTS `player_outfits` (
+  `player_id` int NOT NULL DEFAULT '0',
+  `outfit_id` smallint unsigned NOT NULL DEFAULT '0',
+  `addons` tinyint unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`player_id`,`outfit_id`),
+  FOREIGN KEY (`player_id`) REFERENCES `players`(`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARACTER SET=utf8;
+
+CREATE TABLE IF NOT EXISTS `player_mounts` (
+  `player_id` int NOT NULL DEFAULT '0',
+  `mount_id` smallint unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`player_id`,`mount_id`),
+  FOREIGN KEY (`player_id`) REFERENCES `players`(`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARACTER SET=utf8;
+
 CREATE TABLE IF NOT EXISTS `server_config` (
   `config` varchar(50) NOT NULL,
   `value` varchar(256) NOT NULL DEFAULT '',
@@ -363,7 +379,7 @@ CREATE TABLE IF NOT EXISTS `towns` (
   UNIQUE KEY `name` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARACTER SET=utf8;
 
-INSERT INTO `server_config` (`config`, `value`) VALUES ('db_version', '33'), ('players_record', '0');
+INSERT INTO `server_config` (`config`, `value`) VALUES ('db_version', '35'), ('players_record', '0');
 
 DROP TRIGGER IF EXISTS `ondelete_players`;
 DROP TRIGGER IF EXISTS `oncreate_guilds`;

--- a/src/const.h
+++ b/src/const.h
@@ -688,13 +688,6 @@ static constexpr int32_t CHANNEL_PRIVATE = 0xFFFF;
 //[10000000 - 20000000];
 static constexpr int32_t PSTRG_RESERVED_RANGE_START = 10000000;
 static constexpr int32_t PSTRG_RESERVED_RANGE_SIZE = 10000000;
-//[1000 - 1500];
-static constexpr int32_t PSTRG_OUTFITS_RANGE_START = (PSTRG_RESERVED_RANGE_START + 1000);
-static constexpr int32_t PSTRG_OUTFITS_RANGE_SIZE = 500;
-//[2001 - 2011];
-static constexpr int32_t PSTRG_MOUNTS_RANGE_START = (PSTRG_RESERVED_RANGE_START + 2001);
-static constexpr int32_t PSTRG_MOUNTS_RANGE_SIZE = 10;
-static constexpr int32_t PSTRG_MOUNTS_CURRENTMOUNT = (PSTRG_MOUNTS_RANGE_START + 10);
 
 #define IS_IN_KEYRANGE(key, range) \
 	(key >= PSTRG_##range##_START && ((key - PSTRG_##range##_START) <= PSTRG_##range##_SIZE))

--- a/src/creature.h
+++ b/src/creature.h
@@ -390,6 +390,7 @@ public:
 
 	Outfit_t currentOutfit;
 	Outfit_t defaultOutfit;
+	uint16_t currentMount;
 
 	Position lastPosition;
 	LightInfo internalLight;

--- a/src/mounts.cpp
+++ b/src/mounts.cpp
@@ -25,8 +25,8 @@ bool Mounts::loadFromXml()
 
 	for (auto mountNode : doc.child("mounts").children()) {
 		uint16_t nodeId = pugi::cast<uint16_t>(mountNode.attribute("id").value());
-		if (nodeId == 0 || nodeId > std::numeric_limits<uint8_t>::max()) {
-			std::cout << "[Notice - Mounts::loadFromXml] Mount id \"" << nodeId << "\" is not within 1 and 255 range"
+		if (nodeId == 0 || nodeId > std::numeric_limits<uint16_t>::max()) {
+			std::cout << "[Notice - Mounts::loadFromXml] Mount id \"" << nodeId << "\" is not within 1 and 65535 range"
 			          << std::endl;
 			continue;
 		}
@@ -36,16 +36,16 @@ bool Mounts::loadFromXml()
 			continue;
 		}
 
-		mounts.emplace_back(static_cast<uint8_t>(nodeId), pugi::cast<uint16_t>(mountNode.attribute("clientid").value()),
-		                    mountNode.attribute("name").as_string(),
-		                    pugi::cast<int32_t>(mountNode.attribute("speed").value()),
-		                    mountNode.attribute("premium").as_bool());
+		mounts.emplace_back(
+		    static_cast<uint16_t>(nodeId), pugi::cast<uint16_t>(mountNode.attribute("clientid").value()),
+		    mountNode.attribute("name").as_string(), pugi::cast<int32_t>(mountNode.attribute("speed").value()),
+		    mountNode.attribute("premium").as_bool());
 	}
 	mounts.shrink_to_fit();
 	return true;
 }
 
-Mount* Mounts::getMountByID(uint8_t id)
+Mount* Mounts::getMountByID(uint16_t id)
 {
 	auto it = std::find_if(mounts.begin(), mounts.end(), [id](const Mount& mount) { return mount.id == id; });
 

--- a/src/mounts.h
+++ b/src/mounts.h
@@ -6,14 +6,14 @@
 
 struct Mount
 {
-	Mount(uint8_t id, uint16_t clientId, std::string name, int32_t speed, bool premium) :
+	Mount(uint16_t id, uint16_t clientId, std::string name, int32_t speed, bool premium) :
 	    name(std::move(name)), speed(speed), clientId(clientId), id(id), premium(premium)
 	{}
 
 	std::string name;
 	int32_t speed;
 	uint16_t clientId;
-	uint8_t id;
+	uint16_t id;
 	bool premium;
 };
 
@@ -22,7 +22,7 @@ class Mounts
 public:
 	bool reload();
 	bool loadFromXml();
-	Mount* getMountByID(uint8_t id);
+	Mount* getMountByID(uint16_t id);
 	Mount* getMountByName(const std::string& name);
 	Mount* getMountByClientID(uint16_t clientId);
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -702,15 +702,8 @@ uint16_t Player::getLookCorpse() const
 void Player::addStorageValue(const uint32_t key, const int32_t value, const bool isLogin /* = false*/)
 {
 	if (IS_IN_KEYRANGE(key, RESERVED_RANGE)) {
-		if (IS_IN_KEYRANGE(key, OUTFITS_RANGE)) {
-			outfits.emplace_back(value >> 16, value & 0xFF);
-			return;
-		} else if (IS_IN_KEYRANGE(key, MOUNTS_RANGE)) {
-			// do nothing
-		} else {
-			std::cout << "Warning: unknown reserved key: " << key << " player: " << getName() << std::endl;
-			return;
-		}
+		std::cout << "Warning: unknown reserved key: " << key << " player: " << getName() << std::endl;
+		return;
 	}
 
 	if (value != -1) {
@@ -3913,9 +3906,9 @@ bool Player::canWear(uint32_t lookType, uint8_t addons) const
 		return true;
 	}
 
-	for (const OutfitEntry& outfitEntry : outfits) {
-		if (outfitEntry.lookType == lookType) {
-			if (outfitEntry.addons == addons || outfitEntry.addons == 3 || addons == 0) {
+	for (auto& [outfit, addon] : outfits) {
+		if (outfit == lookType) {
+			if (addon == addons || addon == 3 || addons == 0) {
 				return true;
 			}
 			return false; // have lookType on list and addons don't match
@@ -3935,9 +3928,9 @@ bool Player::hasOutfit(uint32_t lookType, uint8_t addons)
 		return true;
 	}
 
-	for (const OutfitEntry& outfitEntry : outfits) {
-		if (outfitEntry.lookType == lookType) {
-			if (outfitEntry.addons == addons || outfitEntry.addons == 3 || addons == 0) {
+	for (auto& [outfit, addon] : outfits) {
+		if (outfit == lookType) {
+			if (addon == addons || addon == 3 || addons == 0) {
 				return true;
 			}
 			return false; // have lookType on list and addons don't match
@@ -3946,32 +3939,22 @@ bool Player::hasOutfit(uint32_t lookType, uint8_t addons)
 	return false;
 }
 
-void Player::genReservedStorageRange()
-{
-	// generate outfits range
-	uint32_t base_key = PSTRG_OUTFITS_RANGE_START;
-	for (const OutfitEntry& entry : outfits) {
-		storageMap[++base_key] = (entry.lookType << 16) | entry.addons;
-	}
-}
-
 void Player::addOutfit(uint16_t lookType, uint8_t addons)
 {
-	for (OutfitEntry& outfitEntry : outfits) {
-		if (outfitEntry.lookType == lookType) {
-			outfitEntry.addons |= addons;
+	for (auto& [outfit, addon] : outfits) {
+		if (outfit == lookType) {
+			addon |= addons;
 			return;
 		}
 	}
-	outfits.emplace_back(lookType, addons);
+	outfits.insert(std::pair(lookType, addons));
 }
 
 bool Player::removeOutfit(uint16_t lookType)
 {
-	for (auto it = outfits.begin(), end = outfits.end(); it != end; ++it) {
-		OutfitEntry& entry = *it;
-		if (entry.lookType == lookType) {
-			outfits.erase(it);
+	for (auto& [outfit, addon] : outfits) {
+		if (outfit == lookType) {
+			outfits.erase(outfit);
 			return true;
 		}
 	}
@@ -3980,9 +3963,9 @@ bool Player::removeOutfit(uint16_t lookType)
 
 bool Player::removeOutfitAddon(uint16_t lookType, uint8_t addons)
 {
-	for (OutfitEntry& outfitEntry : outfits) {
-		if (outfitEntry.lookType == lookType) {
-			outfitEntry.addons &= ~addons;
+	for (auto& [outfit, addon] : outfits) {
+		if (outfit == lookType) {
+			addon &= ~addons;
 			return true;
 		}
 	}
@@ -4000,12 +3983,12 @@ bool Player::getOutfitAddons(const Outfit& outfit, uint8_t& addons) const
 		return false;
 	}
 
-	for (const OutfitEntry& outfitEntry : outfits) {
-		if (outfitEntry.lookType != outfit.lookType) {
+	for (auto& [lookType, addon] : outfits) {
+		if (lookType != outfit.lookType) {
 			continue;
 		}
 
-		addons = outfitEntry.addons;
+		addons = addon;
 		return true;
 	}
 
@@ -4345,9 +4328,9 @@ GuildEmblems_t Player::getGuildEmblem(const Player* player) const
 	return GUILDEMBLEM_NEUTRAL;
 }
 
-uint8_t Player::getRandomMount() const
+uint16_t Player::getRandomMount() const
 {
-	std::vector<uint8_t> mountsId;
+	std::vector<uint16_t> mountsId;
 	for (const Mount& mount : g_game.mounts.getMounts()) {
 		if (hasMount(&mount)) {
 			mountsId.push_back(mount.id);
@@ -4357,16 +4340,9 @@ uint8_t Player::getRandomMount() const
 	return mountsId[uniform_random(0, mountsId.size() - 1)];
 }
 
-uint8_t Player::getCurrentMount() const
-{
-	int32_t value;
-	if (getStorageValue(PSTRG_MOUNTS_CURRENTMOUNT, value)) {
-		return value;
-	}
-	return 0;
-}
+uint16_t Player::getCurrentMount() const { return currentMount; }
 
-void Player::setCurrentMount(uint8_t mountId) { addStorageValue(PSTRG_MOUNTS_CURRENTMOUNT, mountId); }
+void Player::setCurrentMount(uint16_t mountId) { currentMount = mountId; }
 
 bool Player::toggleMount(bool mount)
 {
@@ -4439,42 +4415,33 @@ bool Player::toggleMount(bool mount)
 	return true;
 }
 
-bool Player::tameMount(uint8_t mountId)
+bool Player::tameMount(uint16_t mountId)
 {
 	if (!g_game.mounts.getMountByID(mountId)) {
 		return false;
 	}
 
-	const uint8_t tmpMountId = mountId - 1;
-	const uint32_t key = PSTRG_MOUNTS_RANGE_START + (tmpMountId / 31);
-
-	int32_t value;
-	if (getStorageValue(key, value)) {
-		value |= (1 << (tmpMountId % 31));
-	} else {
-		value = (1 << (tmpMountId % 31));
+	Mount* mount = g_game.mounts.getMountByID(mountId);
+	if (hasMount(mount)) {
+		return false;
 	}
 
-	addStorageValue(key, value);
+	mounts.insert(mountId);
 	return true;
 }
 
-bool Player::untameMount(uint8_t mountId)
+bool Player::untameMount(uint16_t mountId)
 {
 	if (!g_game.mounts.getMountByID(mountId)) {
 		return false;
 	}
 
-	const uint8_t tmpMountId = mountId - 1;
-	const uint32_t key = PSTRG_MOUNTS_RANGE_START + (tmpMountId / 31);
-
-	int32_t value;
-	if (!getStorageValue(key, value)) {
-		return true;
+	Mount* mount = g_game.mounts.getMountByID(mountId);
+	if (!hasMount(mount)) {
+		return false;
 	}
 
-	value &= ~(1 << (tmpMountId % 31));
-	addStorageValue(key, value);
+	mounts.erase(mountId);
 
 	if (getCurrentMount() == mountId) {
 		if (isMounted()) {
@@ -4498,14 +4465,7 @@ bool Player::hasMount(const Mount* mount) const
 		return false;
 	}
 
-	const uint8_t tmpMountId = mount->id - 1;
-
-	int32_t value;
-	if (!getStorageValue(PSTRG_MOUNTS_RANGE_START + (tmpMountId / 31), value)) {
-		return false;
-	}
-
-	return ((1 << (tmpMountId % 31)) & value) != 0;
+	return mounts.find(mount->id) != mounts.end();
 }
 
 bool Player::hasMounts() const

--- a/src/player.h
+++ b/src/player.h
@@ -71,14 +71,6 @@ struct OpenContainer
 	uint16_t index;
 };
 
-struct OutfitEntry
-{
-	constexpr OutfitEntry(uint16_t lookType, uint8_t addons) : lookType(lookType), addons(addons) {}
-
-	uint16_t lookType;
-	uint8_t addons;
-};
-
 static constexpr int16_t MINIMUM_SKILL_LEVEL = 10;
 
 struct Skill
@@ -119,13 +111,13 @@ public:
 
 	CreatureType_t getType() const override { return CREATURETYPE_PLAYER; }
 
-	uint8_t getRandomMount() const;
-	uint8_t getCurrentMount() const;
-	void setCurrentMount(uint8_t mountId);
+	uint16_t getRandomMount() const;
+	uint16_t getCurrentMount() const;
+	void setCurrentMount(uint16_t mountId);
 	bool isMounted() const { return defaultOutfit.lookMount != 0; }
 	bool toggleMount(bool mount);
-	bool tameMount(uint8_t mountId);
-	bool untameMount(uint8_t mountId);
+	bool tameMount(uint16_t mountId);
+	bool untameMount(uint16_t mountId);
 	bool hasMount(const Mount* mount) const;
 	bool hasMounts() const;
 	void dismount();
@@ -255,7 +247,6 @@ public:
 
 	void addStorageValue(const uint32_t key, const int32_t value, const bool isLogin = false);
 	bool getStorageValue(const uint32_t key, int32_t& value) const;
-	void genReservedStorageRange();
 
 	void setGroup(Group* newGroup) { group = newGroup; }
 	Group* getGroup() const { return group; }
@@ -1190,7 +1181,8 @@ public:
 	std::map<uint32_t, DepotChest*> depotChests;
 	std::map<uint32_t, int32_t> storageMap;
 
-	std::vector<OutfitEntry> outfits;
+	std::map<uint16_t, uint8_t> outfits;
+	std::unordered_set<uint16_t> mounts;
 	GuildWarVector guildWarVector;
 
 	std::list<ShopInfo> shopItemList;


### PR DESCRIPTION
<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper The Forgotten Server code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->

We are moving Outfits(addons) & Mounts from storagevalues into their own respective database tables.
Increased the mount id size from `uint8_t` to `uint16_t` as we already reached 200 mounts and we are soon hitting a wall.


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
