### PR TITLE
IPv6 support

### DIFF
--- a/data/migrations/34.lua
+++ b/data/migrations/34.lua
@@ -1,3 +1,8 @@
 function onUpdateDatabase()
-	return false
+	print("> Updating database to version 34 (IPv6 support)")
+	db.query("ALTER TABLE `players` MODIFY `lastip` varbinary(16) NOT NULL")
+	db.query("ALTER TABLE `ip_bans` MODIFY `ip` varbinary(16) NOT NULL")
+	db.query("UPDATE `players` SET `lastip` = INET6_ATON(INET_NTOA(`lastip`))")
+	db.query("UPDATE `ip_bans` SET `ip` = INET6_ATON(INET_NTOA(`ip`))")
+	return true
 end

--- a/data/migrations/35.lua
+++ b/data/migrations/35.lua
@@ -1,0 +1,3 @@
+function onUpdateDatabase()
+	return false
+end

--- a/schema.sql
+++ b/schema.sql
@@ -47,7 +47,7 @@ CREATE TABLE IF NOT EXISTS `players` (
   `cap` int NOT NULL DEFAULT '400',
   `sex` int NOT NULL DEFAULT '0',
   `lastlogin` bigint unsigned NOT NULL DEFAULT '0',
-  `lastip` int unsigned NOT NULL DEFAULT '0',
+  `lastip` varbinary(16) NOT NULL DEFAULT '0',
   `save` tinyint NOT NULL DEFAULT '1',
   `skull` tinyint NOT NULL DEFAULT '0',
   `skulltime` bigint NOT NULL DEFAULT '0',
@@ -111,7 +111,7 @@ CREATE TABLE IF NOT EXISTS `account_storage` (
 ) ENGINE=InnoDB DEFAULT CHARACTER SET=utf8;
 
 CREATE TABLE IF NOT EXISTS `ip_bans` (
-  `ip` int unsigned NOT NULL,
+  `ip` varbinary(16) NOT NULL,
   `reason` varchar(255) NOT NULL,
   `banned_at` bigint NOT NULL,
   `expires_at` bigint NOT NULL,

--- a/src/ban.cpp
+++ b/src/ban.cpp
@@ -5,11 +5,12 @@
 
 #include "ban.h"
 
+#include "connection.h"
 #include "database.h"
 #include "databasetasks.h"
 #include "tools.h"
 
-bool Ban::acceptConnection(uint32_t clientIP)
+bool Ban::acceptConnection(const Connection::Address& clientIP)
 {
 	std::lock_guard<std::recursive_mutex> lockClass(lock);
 
@@ -71,24 +72,25 @@ bool IOBan::isAccountBanned(uint32_t accountId, BanInfo& banInfo)
 	return true;
 }
 
-bool IOBan::isIpBanned(uint32_t clientIP, BanInfo& banInfo)
+bool IOBan::isIpBanned(const Connection::Address& clientIP, BanInfo& banInfo)
 {
-	if (clientIP == 0) {
+	if (clientIP.is_unspecified()) {
 		return false;
 	}
 
 	Database& db = Database::getInstance();
 
 	DBResult_ptr result = db.storeQuery(fmt::format(
-	    "SELECT `reason`, `expires_at`, (SELECT `name` FROM `players` WHERE `id` = `banned_by`) AS `name` FROM `ip_bans` WHERE `ip` = {:d}",
-	    clientIP));
+	    "SELECT `reason`, `expires_at`, (SELECT `name` FROM `players` WHERE `id` = `banned_by`) AS `name` FROM `ip_bans` WHERE `ip` = INET6_ATON('{:s}')",
+	    clientIP.to_string()));
 	if (!result) {
 		return false;
 	}
 
 	int64_t expiresAt = result->getNumber<int64_t>("expires_at");
 	if (expiresAt != 0 && time(nullptr) > expiresAt) {
-		g_databaseTasks.addTask(fmt::format("DELETE FROM `ip_bans` WHERE `ip` = {:d}", clientIP));
+		g_databaseTasks.addTask(
+		    fmt::format("DELETE FROM `ip_bans` WHERE `ip` = INET6_ATON('{:s}')", clientIP.to_string()));
 		return false;
 	}
 

--- a/src/ban.h
+++ b/src/ban.h
@@ -4,6 +4,8 @@
 #ifndef FS_BAN_H
 #define FS_BAN_H
 
+#include "connection.h"
+
 struct BanInfo
 {
 	std::string bannedBy;
@@ -22,12 +24,12 @@ struct ConnectBlock
 	uint32_t count;
 };
 
-using IpConnectMap = std::map<uint32_t, ConnectBlock>;
+using IpConnectMap = std::map<Connection::Address, ConnectBlock>;
 
 class Ban
 {
 public:
-	bool acceptConnection(uint32_t clientIP);
+	bool acceptConnection(const Connection::Address& clientIP);
 
 private:
 	IpConnectMap ipConnectMap;
@@ -38,7 +40,7 @@ class IOBan
 {
 public:
 	static bool isAccountBanned(uint32_t accountId, BanInfo& banInfo);
-	static bool isIpBanned(uint32_t clientIP, BanInfo& banInfo);
+	static bool isIpBanned(const Connection::Address& clientIP, BanInfo& banInfo);
 	static bool isPlayerNamelocked(uint32_t playerId);
 };
 

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -98,6 +98,12 @@ void Connection::accept()
 	}
 
 	std::lock_guard<std::recursive_mutex> lockClass(connectionLock);
+
+	boost::system::error_code error;
+	if (auto endpoint = socket.remote_endpoint(error); !error) {
+		remoteAddress = endpoint.address();
+	}
+
 	try {
 		readTimer.expires_from_now(std::chrono::seconds(CONNECTION_READ_TIMEOUT));
 		readTimer.async_wait(
@@ -135,7 +141,7 @@ void Connection::parseHeader(const boost::system::error_code& error)
 	uint32_t timePassed = std::max<uint32_t>(1, (time(nullptr) - timeConnected) + 1);
 	if ((++packetsSent / timePassed) >
 	    static_cast<uint32_t>(g_config.getNumber(ConfigManager::MAX_PACKETS_PER_SECOND))) {
-		std::cout << convertIPToString(getIP()) << " disconnected for exceeding packet per second limit." << std::endl;
+		std::cout << getIP() << " disconnected for exceeding packet per second limit." << std::endl;
 		close();
 		return;
 	}
@@ -289,20 +295,6 @@ void Connection::internalSend(const OutputMessage_ptr& msg)
 		std::cout << "[Network error - Connection::internalSend] " << e.what() << std::endl;
 		close(FORCE_CLOSE);
 	}
-}
-
-uint32_t Connection::getIP()
-{
-	std::lock_guard<std::recursive_mutex> lockClass(connectionLock);
-
-	// IP-address is expressed in network byte order
-	boost::system::error_code error;
-	const boost::asio::ip::tcp::endpoint endpoint = socket.remote_endpoint(error);
-	if (error) {
-		return 0;
-	}
-
-	return htonl(endpoint.address().to_v4().to_ulong());
 }
 
 void Connection::onWriteOperation(const boost::system::error_code& error)

--- a/src/connection.h
+++ b/src/connection.h
@@ -61,6 +61,7 @@ private:
 class Connection : public std::enable_shared_from_this<Connection>
 {
 public:
+	using Address = boost::asio::ip::address;
 	// non-copyable
 	Connection(const Connection&) = delete;
 	Connection& operator=(const Connection&) = delete;
@@ -88,7 +89,7 @@ public:
 
 	void send(const OutputMessage_ptr& msg);
 
-	uint32_t getIP();
+	const Address& getIP() const { return remoteAddress; };
 
 private:
 	void parseHeader(const boost::system::error_code& error);
@@ -117,7 +118,7 @@ private:
 	Protocol_ptr protocol;
 
 	boost::asio::ip::tcp::socket socket;
-
+	Address remoteAddress;
 	time_t timeConnected;
 	uint32_t packetsSent = 0;
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5190,7 +5190,7 @@ void Game::playerDebugAssert(uint32_t playerId, const std::string& assertLine, c
 	FILE* file = fopen("client_assertions.txt", "a");
 	if (file) {
 		fprintf(file, "----- %s - %s (%s) -----\n", formatDate(time(nullptr)).c_str(), player->getName().c_str(),
-		        convertIPToString(player->getIP()).c_str());
+		        player->getIP().to_string().c_str());
 		fprintf(file, "%s\n%s\n%s\n%s\n", assertLine.c_str(), date.c_str(), description.c_str(), comment.c_str());
 		fclose(file);
 	}

--- a/src/iologindata.cpp
+++ b/src/iologindata.cpp
@@ -737,8 +737,9 @@ bool IOLoginData::savePlayer(Player* player)
 	}
 
 	if (result->getNumber<uint16_t>("save") == 0) {
-		return db.executeQuery(fmt::format("UPDATE `players` SET `lastlogin` = {:d}, `lastip` = {:d} WHERE `id` = {:d}",
-		                                   player->lastLoginSaved, player->lastIP, player->getGUID()));
+		return db.executeQuery(
+		    fmt::format("UPDATE `players` SET `lastlogin` = {:d}, `lastip` = INET6_ATON('{:s}') WHERE `id` = {:d}",
+		                player->lastLoginSaved, player->lastIP.to_string(), player->getGUID()));
 	}
 
 	// serialize conditions
@@ -793,8 +794,8 @@ bool IOLoginData::savePlayer(Player* player)
 		query << "`lastlogin` = " << player->lastLoginSaved << ',';
 	}
 
-	if (player->lastIP != 0) {
-		query << "`lastip` = " << player->lastIP << ',';
+	if (!player->lastIP.is_unspecified()) {
+		query << "`lastip` = INET6_ATON('" << player->lastIP.to_string() << "'),";
 	}
 
 	query << "`conditions` = " << db.escapeBlob(conditions, conditionsSize) << ',';

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -8661,7 +8661,7 @@ int LuaScriptInterface::luaPlayerGetIp(lua_State* L)
 	// player:getIp()
 	Player* player = getUserdata<Player>(L, 1);
 	if (player) {
-		lua_pushnumber(L, player->getIP());
+		pushString(L, player->getIP().to_string());
 	} else {
 		lua_pushnil(L);
 	}

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -2106,13 +2106,13 @@ BlockType_t Player::blockHit(Creature* attacker, CombatType_t combatType, int32_
 	return blockType;
 }
 
-uint32_t Player::getIP() const
+Connection::Address Player::getIP() const
 {
 	if (client) {
 		return client->getIP();
 	}
 
-	return 0;
+	return {};
 }
 
 void Player::death(Creature* lastHitCreature)

--- a/src/player.h
+++ b/src/player.h
@@ -241,7 +241,7 @@ public:
 			client->disconnect();
 		}
 	}
-	uint32_t getIP() const;
+	Connection::Address getIP() const;
 
 	void addContainer(uint8_t cid, Container* container);
 	void closeContainer(uint8_t cid);
@@ -1231,6 +1231,7 @@ private:
 	int64_t nextAction = 0;
 
 	ProtocolGame_ptr client;
+	Connection::Address lastIP = {};
 	BedItem* bedItem = nullptr;
 	Guild* guild = nullptr;
 	GuildRank_ptr guildRank = nullptr;
@@ -1260,7 +1261,6 @@ private:
 	uint32_t nextStepEvent = 0;
 	uint32_t walkTaskEvent = 0;
 	uint32_t MessageBufferTicks = 0;
-	uint32_t lastIP = 0;
 	uint32_t accountNumber = 0;
 	uint32_t guid = 0;
 	uint32_t windowTextId = 0;

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -88,11 +88,11 @@ bool Protocol::RSA_decrypt(NetworkMessage& msg)
 	return msg.getByte() == 0;
 }
 
-uint32_t Protocol::getIP() const
+Connection::Address Protocol::getIP() const
 {
 	if (auto connection = getConnection()) {
 		return connection->getIP();
 	}
 
-	return 0;
+	return {};
 }

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -28,7 +28,7 @@ public:
 
 	Connection_ptr getConnection() const { return connection.lock(); }
 
-	uint32_t getIP() const;
+	Connection::Address getIP() const;
 
 	// Use this function for autosend messages only
 	OutputMessage_ptr getOutputBuffer(int32_t size);

--- a/src/protocolstatus.h
+++ b/src/protocolstatus.h
@@ -36,7 +36,7 @@ public:
 	static const uint64_t start;
 
 private:
-	static std::map<uint32_t, int64_t> ipConnectMap;
+	static std::map<Connection::Address, int64_t> ipConnectMap;
 };
 
 #endif // FS_PROTOCOLSTATUS_H

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -12,6 +12,25 @@
 extern ConfigManager g_config;
 Ban g_bans;
 
+namespace {
+
+boost::asio::ip::address getListenAddress()
+{
+	if (g_config.getBoolean(ConfigManager::BIND_ONLY_GLOBAL_ADDRESS)) {
+		return boost::asio::ip::address::from_string(g_config.getString(ConfigManager::IP));
+	}
+	return boost::asio::ip::address_v6::any();
+}
+
+void openAcceptor(std::weak_ptr<ServicePort> weak_service, uint16_t port)
+{
+	if (auto service = weak_service.lock()) {
+		service->open(port);
+	}
+}
+
+} // namespace
+
 ServiceManager::~ServiceManager() { stop(); }
 
 void ServiceManager::die() { io_service.stop(); }
@@ -84,8 +103,8 @@ void ServicePort::onAccept(Connection_ptr connection, const boost::system::error
 			return;
 		}
 
-		auto remote_ip = connection->getIP();
-		if (remote_ip != 0 && g_bans.acceptConnection(remote_ip)) {
+		const auto& remote_ip = connection->getIP();
+		if (g_bans.acceptConnection(remote_ip)) {
 			Service_ptr service = services.front();
 			if (service->is_single_socket()) {
 				connection->accept(service->make_protocol(connection));
@@ -101,9 +120,9 @@ void ServicePort::onAccept(Connection_ptr connection, const boost::system::error
 		if (!pendingStart) {
 			close();
 			pendingStart = true;
-			g_scheduler.addEvent(
-			    createSchedulerTask(15000, [=, thisPtr = std::weak_ptr<ServicePort>(shared_from_this())]() {
-				    ServicePort::openAcceptor(thisPtr, serverPort);
+			g_scheduler.addEvent(createSchedulerTask(
+			    15000, [serverPort = this->serverPort, service = std::weak_ptr<ServicePort>(shared_from_this())]() {
+				    openAcceptor(service, serverPort);
 			    }));
 		}
 	}
@@ -123,44 +142,41 @@ Protocol_ptr ServicePort::make_protocol(NetworkMessage& msg, const Connection_pt
 
 void ServicePort::onStopServer() { close(); }
 
-void ServicePort::openAcceptor(std::weak_ptr<ServicePort> weak_service, uint16_t port)
-{
-	if (auto service = weak_service.lock()) {
-		service->open(port);
-	}
-}
-
 void ServicePort::open(uint16_t port)
 {
+	namespace ip = boost::asio::ip;
+
 	close();
 
 	serverPort = port;
 	pendingStart = false;
 
 	try {
-		if (g_config.getBoolean(ConfigManager::BIND_ONLY_GLOBAL_ADDRESS)) {
-			acceptor.reset(new boost::asio::ip::tcp::acceptor(
-			    io_service,
-			    boost::asio::ip::tcp::endpoint(boost::asio::ip::address(boost::asio::ip::address_v4::from_string(
-			                                       g_config.getString(ConfigManager::IP))),
-			                                   serverPort)));
-		} else {
-			acceptor.reset(new boost::asio::ip::tcp::acceptor(
-			    io_service, boost::asio::ip::tcp::endpoint(
-			                    boost::asio::ip::address(boost::asio::ip::address_v4(INADDR_ANY)), serverPort)));
-		}
+		auto address = getListenAddress();
 
-		acceptor->set_option(boost::asio::ip::tcp::no_delay(true));
+		acceptor = std::make_unique<ip::tcp::acceptor>(io_service, ip::tcp::endpoint{address, serverPort});
+		if (address.is_v6()) {
+			ip::v6_only option;
+			acceptor->get_option(option);
+			if (option) {
+				boost::system::error_code err;
+				acceptor->set_option(ip::v6_only{false}, err);
+				if (err) {
+					std::cout << "[Warning - ServicePort::open] Enabling IPv4 support failed: " << err.message()
+					          << std::endl;
+				}
+			}
+		}
+		acceptor->set_option(ip::tcp::no_delay{true});
 
 		accept();
 	} catch (boost::system::system_error& e) {
 		std::cout << "[ServicePort::open] Error: " << e.what() << std::endl;
 
 		pendingStart = true;
-		g_scheduler.addEvent(
-		    createSchedulerTask(15000, [=, thisPtr = std::weak_ptr<ServicePort>(shared_from_this())]() {
-			    ServicePort::openAcceptor(thisPtr, serverPort);
-		    }));
+		g_scheduler.addEvent(createSchedulerTask(
+		    15000,
+		    [port, service = std::weak_ptr<ServicePort>(shared_from_this())]() { openAcceptor(service, port); }));
 	}
 }
 

--- a/src/server.h
+++ b/src/server.h
@@ -40,7 +40,6 @@ public:
 	ServicePort(const ServicePort&) = delete;
 	ServicePort& operator=(const ServicePort&) = delete;
 
-	static void openAcceptor(std::weak_ptr<ServicePort> weak_service, uint16_t port);
 	void open(uint16_t port);
 	void close();
 	bool is_single_socket() const;

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -308,18 +308,6 @@ bool boolean_random(double probability /* = 0.5*/)
 	return booleanRand(getRandomGenerator(), std::bernoulli_distribution::param_type(probability));
 }
 
-std::string convertIPToString(uint32_t ip)
-{
-	char buffer[17];
-
-	int res = sprintf(buffer, "%u.%u.%u.%u", ip & 0xFF, (ip >> 8) & 0xFF, (ip >> 16) & 0xFF, (ip >> 24));
-	if (res < 0) {
-		return {};
-	}
-
-	return buffer;
-}
-
 std::string formatDate(time_t time)
 {
 	const tm* tms = localtime(&time);

--- a/src/tools.h
+++ b/src/tools.h
@@ -39,7 +39,6 @@ std::string getFirstLine(const std::string& str);
 
 std::string formatDate(time_t time);
 std::string formatDateShort(time_t time);
-std::string convertIPToString(uint32_t ip);
 
 uint16_t getDepotBoxId(uint16_t index);
 MagicEffectClasses getMagicEffect(const std::string& strValue);


### PR DESCRIPTION
Implemented support for IPv6 connections. The server now listens on an IPv6 socket unless it's configured to only bind to a specific IPv4 address. The address is now stored as a varchar in the database. The internal representation of the address has been changed to the asio-native one for simplicity.

- Remove convertIPToString()

This function is not used anymore.

- Switch to ip column to VARBINARY(16)

varbinary(16) offers greater space efficiency than a character string. Changed the bound acceptor address to a static to prevent constructing it on every connection

Signed-off-by: Damian Jarek <damian.jarek93@gmail.com>
Co-authored-by: Evil Puncker <EPuncker@users.noreply.github.com>
Co-authored-by: Ranieri Althoff <ranisalt@gmail.com>

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving The Forgotten Server! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [ ] I have followed [proper The Forgotten Server code styling][code].
- [ ] I have read and understood the [contribution guidelines][cont] before making this PR.
- [ ] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed

<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->


<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/otland/forgottenserver/wiki/Contributing
[code]: https://github.com/otland/forgottenserver/wiki/TFS-Coding-Style-Guide
